### PR TITLE
Prompt merchant change image

### DIFF
--- a/app/controllers/dashboard/dashboard_controller.rb
+++ b/app/controllers/dashboard/dashboard_controller.rb
@@ -2,5 +2,6 @@ class Dashboard::DashboardController < Dashboard::BaseController
   def index
     @merchant = current_user
     @pending_orders = Order.pending_orders_for_merchant(current_user.id)
+    @items = @merchant.items
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -48,4 +48,9 @@ class Item < ApplicationRecord
   def ordered?
     order_items.count > 0
   end
+
+  def default_image?
+    image == "https://picsum.photos/200/300?image=1"
+  end
+
 end

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -13,6 +13,15 @@
   </div>
 </div>
 
+<% if current_merchant? && current_user == @merchant && @items.any?(&:default_image?) %>
+<section id="add-image">
+<p>These items need images:</p>
+  <% @items.each do |item| %>
+  <p><%= link_to item.name, edit_dashboard_item_path(item) if item.default_image? %></p>
+  <% end %>
+</section>
+<% end %>
+
 <%= tag.div class: "card" do %>
   <%= tag.section class: "statistics card-body float-left m-4" do %>
     <%= tag.section id: "top-items-sold-by-quantity", class: "card-body float-left m-2" do %>

--- a/db/migrate/20190403153337_create_items.rb
+++ b/db/migrate/20190403153337_create_items.rb
@@ -5,7 +5,7 @@ class CreateItems < ActiveRecord::Migration[5.1]
       t.boolean :active, default: false
       t.decimal :price
       t.text :description
-      t.string :image
+      t.string :image, default: "https://picsum.photos/200/300?image=1"
       t.integer :inventory
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20190403231217) do
     t.boolean "active", default: false
     t.decimal "price"
     t.text "description"
-    t.string "image"
+    t.string "image", default: "https://picsum.photos/200/300?image=1"
     t.integer "inventory"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :user, factory: :merchant
     sequence(:name) { |n| "Item Name #{n}" }
     sequence(:description) { |n| "Description #{n}" }
-    sequence(:image) { |n| "https://picsum.photos/200/300?image=#{n}" }
+    # sequence(:image) { |n| "https://picsum.photos/200/300?image=#{n}" }
     sequence(:price) { |n| ("#{n}".to_i+1)*1.5 }
     sequence(:inventory) { |n| ("#{n}".to_i+1)*2 }
     active { true }

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'merchant dashboard' do
     @merchant = create(:merchant)
     @admin = create(:admin)
     @i1, @i2 = create_list(:item, 2, user: @merchant)
+    @i3 = create(:item, user: @merchant, image:"http://clipart-library.com/images/6Tpo6G8TE.jpg")
 
     @o1, @o2 = create_list(:order, 2)
     @o3 = create(:shipped_order)
@@ -43,7 +44,6 @@ RSpec.describe 'merchant dashboard' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
       visit dashboard_path
-      save_and_open_page
     end
     it 'shows merchant information' do
       expect(page).to have_content(@merchant.name)
@@ -93,10 +93,23 @@ RSpec.describe 'merchant dashboard' do
         expect(current_path).to eq(admin_merchant_items_path(@merchant))
       end
     end
-#     As a Merchant, When I visit my dashboard
-# -for each item using a placeholder image
-# -A item appears on a list
-# -On this least each items name is a link to that items edit page
 
+    describe "merchant is prompted to add image" do
+      it "shows a list of items with default image" do
+        visit dashboard_path
+        within "#add-image" do
+          expect(page).to have_content("These items need images:")
+          expect(page).to_not have_content(@i3.name)
+          click_link @i1.name
+        end
+        expect(current_path).to eq(edit_dashboard_item_path(@i1))
+        visit dashboard_path
+        within "#add-image" do
+          click_link @i2.name
+          expect(page).to_not have_content(@i3.name)
+        end
+          expect(current_path).to eq(edit_dashboard_item_path(@i2))
+      end
+    end
   end
 end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'merchant dashboard' do
     @merchant = create(:merchant)
     @admin = create(:admin)
     @i1, @i2 = create_list(:item, 2, user: @merchant)
+
     @o1, @o2 = create_list(:order, 2)
     @o3 = create(:shipped_order)
     @o4 = create(:cancelled_order)
@@ -42,6 +43,7 @@ RSpec.describe 'merchant dashboard' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
       visit dashboard_path
+      save_and_open_page
     end
     it 'shows merchant information' do
       expect(page).to have_content(@merchant.name)
@@ -91,5 +93,10 @@ RSpec.describe 'merchant dashboard' do
         expect(current_path).to eq(admin_merchant_items_path(@merchant))
       end
     end
+#     As a Merchant, When I visit my dashboard
+# -for each item using a placeholder image
+# -A item appears on a list
+# -On this least each items name is a link to that items edit page
+
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Item, type: :model do
       @order_item_4 = create(:order_item, item: @item, created_at: 2.days.ago, updated_at: 1.day.ago)
     end
 
+    describe "#default_image?" do
+      it "check if an image is the default image" do
+        item = create(:item, user: @merchant, image: "http://clipart-library.com/images/6Tpo6G8TE.jpg")
+        expect(item.default_image?).to eq(false)
+        expect(@item.default_image?).to eq(true)
+
+      end
+    end
+
     describe "#average_fulfillment_time" do
       it "calculates the average number of seconds between order_item creation and completion" do
         expect(@item.average_fulfillment_time).to eq(158400)


### PR DESCRIPTION
This PR
-Adds default image to the database for items
-Adds item default image? model instance method and test
-Adds spec to merchants dashboard page checking for alert of items that need image changed
-Adds view block to merchant dashboard index that only appears if user is merchant and any items use default image