### PR TITLE
User deletes address no crash

### DIFF
--- a/app/views/users/_profile.erb
+++ b/app/views/users/_profile.erb
@@ -4,6 +4,8 @@
   <h2>Order Data</h2>
   <p>Email: <%= @user.email %></p>
   <p>Role: <%= @user.role %></p>
+
+  <% if !@addresses.empty? %>
   <aside id="address-details">
     <h3>Primary Address:</h3>
     <p><%= @user.addresses.first.address %></p>
@@ -13,8 +15,10 @@
       <%= @user.addresses.first.zip %>
     </p>
   </aside>
+<% end %>
+
   <%= link_to "Add address", new_user_address_path(@user) %>
-  <% if @addresses %>
+  <% if !@addresses.empty? %>
     <p>My Addresses</p>
     <%  @addresses.each do |address| %>
     <section id="address-<%=address.id%>">

--- a/app/views/users/_profile.erb
+++ b/app/views/users/_profile.erb
@@ -5,7 +5,7 @@
   <p>Email: <%= @user.email %></p>
   <p>Role: <%= @user.role %></p>
   <aside id="address-details">
-    <h3>Address:</h3>
+    <h3>Primary Address:</h3>
     <p><%= @user.addresses.first.address %></p>
     <p>
       <%= @user.addresses.first.city %>,
@@ -15,7 +15,7 @@
   </aside>
   <%= link_to "Add address", new_user_address_path(@user) %>
   <% if @addresses %>
-    <p>Other Addresses</p>
+    <p>My Addresses</p>
     <%  @addresses.each do |address| %>
     <section id="address-<%=address.id%>">
       <p>

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -186,6 +186,16 @@ RSpec.describe 'user profile', type: :feature do
 
     end
 
+    it "still loads my profile page when I have no addresses" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit profile_path
+      within 'h3' do
+        expect(page).to_not have_content('Primary Address:')
+      end
+      expect(page).to_not have_content('My Addresses')
+    end
+
 
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -190,9 +190,7 @@ RSpec.describe 'user profile', type: :feature do
       user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       visit profile_path
-      within 'h3' do
         expect(page).to_not have_content('Primary Address:')
-      end
       expect(page).to_not have_content('My Addresses')
     end
 

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -194,6 +194,23 @@ RSpec.describe 'user profile', type: :feature do
       expect(page).to_not have_content('My Addresses')
     end
 
+    it "still shows user addresses when they exist" do
+      user = create(:user)
+      address = create(:address, user: user)
+      address2 = create(:address, user: user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit profile_path
+      within "#address-details" do
+        expect(page).to have_content(user.addresses.first.address)
+      end
+      within "#address-#{address.id}" do
+        expect(page).to have_link("Delete #{address.nick_name}")
+      end
+      within "#address-#{address2.id}" do
+        expect(page).to have_link("Delete #{address2.nick_name}")
+      end
+    end
+
 
   end
 end


### PR DESCRIPTION
This PR 
-Adds spec and conditional logic to view page not to crash if user deletes all addresses
-Still errors if user deletes address associated with order
