### PR TITLE
Cannot delete associated addresses

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -11,14 +11,25 @@ class AddressesController < ApplicationController
   end
 
   def edit
-    @address = Address.find(params[:id])
-    @user = User.find(params[:user_id])
+    address = Address.find(params[:id])
+    if address.editable?
+      @address = address
+      @user = User.find(params[:user_id])
+    else
+      flash[:warning] = "Cannot Edit #{address.nick_name}, it is associated with a packaged or shipped order"
+      redirect_to profile_path
+    end
   end
 
   def update
     address = Address.find(params[:id])
+    if address.editable?
     address.update(address_params)
     redirect_to profile_path
+    else
+      flash[:warning] = "Cannot Edit #{address.nick_name}, it is associated with a packaged or shipped order"
+      redirect_to profile_path
+    end
   end
 
   def destroy

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -22,6 +22,7 @@ class AddressesController < ApplicationController
   end
 
   def destroy
+    
     address = Address.find(params[:id])
     address.orders.each{|order| order.update(address_id: nil)}
     address.destroy

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -22,11 +22,15 @@ class AddressesController < ApplicationController
   end
 
   def destroy
-    
     address = Address.find(params[:id])
-    address.orders.each{|order| order.update(address_id: nil)}
-    address.destroy
-    redirect_to profile_path
+    if address.editable?
+      address.orders.each{|order| order.update(address_id: nil)}
+      address.destroy
+      redirect_to profile_path
+    else
+      flash[:warning] = "Cannot Delete #{address.nick_name}, it is associated with a packaged or shipped order"
+      redirect_to profile_path
+    end
 
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,4 +2,8 @@ class Address < ApplicationRecord
   validates_presence_of :nick_name, :address, :city, :state, :zip
   belongs_to :user
   has_many :orders
+
+  def editable?
+    orders.select(:status).where(status: [1, 2]).empty?
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,8 @@ require 'factory_bot_rails'
 
 include FactoryBot::Syntax::Methods
 
-# OrderItem.destroy_all
-# Order.destroy_all
+OrderItem.destroy_all
+Order.destroy_all
 Address.destroy_all
 Item.destroy_all
 User.destroy_all
@@ -12,6 +12,8 @@ User.destroy_all
 admin = create(:admin)
 user_1, user_2 = create_list(:user, 2)
 address_1 = create(:address, user: user_1)
+address_9 = create(:address, user: user_1, nick_name: "Work")
+address_10 = create(:address, user: user_1, nick_name: "School")
 address_2 = create(:address, user: user_2)
 merchant_1 = create(:merchant)
 
@@ -34,6 +36,12 @@ create_list(:item, 10, user: merchant_1)
 
 inactive_item_1 = create(:inactive_item, user: merchant_1)
 inactive_item_2 = create(:inactive_item, user: inactive_merchant_1)
+
+packaged_order = create(:packaged_order, user: user_1, address: address_9)
+shipped_order = create(:shipped_order, user: user_1, address: address_10)
+
+create(:order_item, order: packaged_order, item: item_4)
+create(:order_item, order: shipped_order, item: item_3)
 
 # Random.new_seed
 # rng = Random.new

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -316,17 +316,18 @@ RSpec.describe 'user profile', type: :feature do
         end
         expect(current_path).to eq(profile_path)
         expect(page).to have_content("Cannot Delete #{address3.nick_name}, it is associated with a packaged or shipped order")
-        expect(page).to have_css("#address-#{address3.nick_name}")
+        save_and_open_page
+        expect(page).to have_css("#address-#{address3.id}")
         within "#address-#{address2.id}" do #shipped canot
           click_link("Delete #{address2.nick_name}")
         end
         expect(page).to have_content("Cannot Delete #{address2.nick_name}, it is associated with a packaged or shipped order")
-        expect(page).to have_css("#address-#{address2.nick_name}")
+        expect(page).to have_css("#address-#{address2.id}")
         within "#address-#{address.id}" do #pending can
           click_link("Delete #{address.nick_name}")
         end
         expect(page).to_not have_content("Cannot Delete #{address.nick_name}, it is associated with a packaged or shipped order")
-        expect(page).to_not have_css("#address-#{address.nick_name}")
+        expect(page).to_not have_css("#address-#{address.id}")
 
       end
     end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -276,7 +276,6 @@ RSpec.describe 'user profile', type: :feature do
           click_link("Change Address to #{address2.nick_name}")
         end
         expect(current_path).to eq(profile_orders_path)
-        save_and_open_page
         within "#order-#{pending_order.id}" do
           expect(page).to have_content("Address: #{address2.nick_name}")
         end
@@ -308,7 +307,6 @@ RSpec.describe 'user profile', type: :feature do
         within "#address-#{address4.id}" do #cancelled can change
           click_link("Delete #{address4.nick_name}")
         end
-        save_and_open_page
         expect(current_path).to eq(profile_path)
         expect(page).to_not have_css("#address-#{address4.nick_name}")
         within "#address-#{address3.id}" do #packaged cannot
@@ -316,7 +314,6 @@ RSpec.describe 'user profile', type: :feature do
         end
         expect(current_path).to eq(profile_path)
         expect(page).to have_content("Cannot Delete #{address3.nick_name}, it is associated with a packaged or shipped order")
-        save_and_open_page
         expect(page).to have_css("#address-#{address3.id}")
         within "#address-#{address2.id}" do #shipped canot
           click_link("Delete #{address2.nick_name}")

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -289,5 +289,47 @@ RSpec.describe 'user profile', type: :feature do
       end
     end
 
+    describe "addresses with associated orders cant be changed" do
+      it "does not allow me to delete an address associated with a packaged/shipped order" do
+        click_link("Log out")
+        user = create(:user)
+        address = create(:address, user:user)
+        address2 = create(:address, user:user, nick_name: 'school' )
+        address3 = create(:address, user:user, nick_name: 'work' )
+        address4 = create(:address, user:user, nick_name: 'other' )
+
+        pending_order = create(:order, user: user, address: address)
+        pending_order2 = create(:order, user: user, address: address4)
+        packaged_order = create(:packaged_order, user: user, address: address3)
+        shipped_order = create(:shipped_order, user: user, address: address2)
+        cancelled_order = create(:cancelled_order, user: user, address: address4)
+        login_as(user)
+        visit profile_path
+        within "#address-#{address4.id}" do #cancelled can change
+          click_link("Delete #{address4.nick_name}")
+        end
+        save_and_open_page
+        expect(current_path).to eq(profile_path)
+        expect(page).to_not have_css("#address-#{address4.nick_name}")
+        within "#address-#{address3.id}" do #packaged cannot
+          click_link("Delete #{address3.nick_name}")
+        end
+        expect(current_path).to eq(profile_path)
+        expect(page).to have_content("Cannot Delete #{address3.nick_name}, it is associated with a packaged or shipped order")
+        expect(page).to have_css("#address-#{address3.nick_name}")
+        within "#address-#{address2.id}" do #shipped canot
+          click_link("Delete #{address2.nick_name}")
+        end
+        expect(page).to have_content("Cannot Delete #{address2.nick_name}, it is associated with a packaged or shipped order")
+        expect(page).to have_css("#address-#{address2.nick_name}")
+        within "#address-#{address.id}" do #pending can
+          click_link("Delete #{address.nick_name}")
+        end
+        expect(page).to_not have_content("Cannot Delete #{address.nick_name}, it is associated with a packaged or shipped order")
+        expect(page).to_not have_css("#address-#{address.nick_name}")
+
+      end
+    end
+
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -325,6 +325,51 @@ RSpec.describe 'user profile', type: :feature do
         end
         expect(page).to_not have_content("Cannot Delete #{address.nick_name}, it is associated with a packaged or shipped order")
         expect(page).to_not have_css("#address-#{address.id}")
+      end
+      it "does not allow me to delete an address associated with a packaged/shipped order" do
+        click_link("Log out")
+        user = create(:user)
+        address = create(:address, user:user)
+        address2 = create(:address, user:user, nick_name: 'school' )
+        address3 = create(:address, user:user, nick_name: 'work' )
+        address4 = create(:address, user:user, nick_name: 'other' )
+
+        pending_order = create(:order, user: user, address: address)
+        pending_order2 = create(:order, user: user, address: address4)
+        packaged_order = create(:packaged_order, user: user, address: address3)
+        shipped_order = create(:shipped_order, user: user, address: address2)
+        cancelled_order = create(:cancelled_order, user: user, address: address4)
+        login_as(user)
+        visit profile_path
+        within "#address-#{address4.id}" do #cancelled can change
+          click_link("Edit #{address4.nick_name}")
+        end
+        fill_in "address_name", with: "a new address"
+        click_button "Edit Address"
+        expect(current_path).to eq(profile_path)
+        within("#address-#{address4.nick_name}") do
+          expect(page).to have_content("a new address")
+        end
+        within "#address-#{address3.id}" do #packaged cannot
+          click_link("Edit #{address3.nick_name}")
+        end
+        expect(current_path).to eq(profile_path)
+        expect(page).to have_content("Cannot Edit #{address3.nick_name}, it is associated with a packaged or shipped order")
+        expect(page).to have_css("#address-#{address3.id}")
+        within "#address-#{address2.id}" do #shipped canot
+          click_link("Edit #{address2.nick_name}")
+        end
+        expect(page).to have_content("Cannot Edit #{address2.nick_name}, it is associated with a packaged or shipped order")
+        expect(page).to have_css("#address-#{address2.id}")
+        within "#address-#{address.id}" do #pending can
+          click_link("Edit #{address.nick_name}")
+        end
+        fill_in "address_state", with: "Mississippi"
+        click_button "Edit Address"
+        expect(page).to_not have_content("Cannot Edit #{address.nick_name}, it is associated with a packaged or shipped order")
+        within ("#address-#{address.id}") do
+          expect(page).to have_content("Mississippi")
+        end
 
       end
     end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -344,10 +344,10 @@ RSpec.describe 'user profile', type: :feature do
         within "#address-#{address4.id}" do #cancelled can change
           click_link("Edit #{address4.nick_name}")
         end
-        fill_in "address_name", with: "a new address"
-        click_button "Edit Address"
+        fill_in "address_nick_name", with: "a new address"
+        click_button "Update Address"
         expect(current_path).to eq(profile_path)
-        within("#address-#{address4.nick_name}") do
+        within("#address-#{address4.id}") do
           expect(page).to have_content("a new address")
         end
         within "#address-#{address3.id}" do #packaged cannot
@@ -365,7 +365,7 @@ RSpec.describe 'user profile', type: :feature do
           click_link("Edit #{address.nick_name}")
         end
         fill_in "address_state", with: "Mississippi"
-        click_button "Edit Address"
+        click_button "Update Address"
         expect(page).to_not have_content("Cannot Edit #{address.nick_name}, it is associated with a packaged or shipped order")
         within ("#address-#{address.id}") do
           expect(page).to have_content("Mississippi")

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -13,4 +13,24 @@ RSpec.describe Address, type: :model do
     it { should belong_to :user }
     it { should have_many :orders }
   end
+
+  describe "instance methods" do
+    it ".editable?" do
+      user = create(:user)
+      address = create(:address, user: user)
+      address2 = create(:address, user: user, nick_name: 'school')
+      address3 = create(:address, user: user, nick_name: 'work')
+      address4 = create(:address, user: user, nick_name: 'other')
+      pending_order = create(:order, user: user, address: address)
+      pending_order2 = create(:order, user: user, address: address2)
+      packaged_order = create(:packaged_order, user: user, address: address2)
+      shipped_order = create(:shipped_order, user: user, address: address3)
+      cancelled_order = create(:cancelled_order, user: user, address: address4)
+      expect(address.editable?).to eq(true)
+      expect(address2.editable?).to eq(false)
+      expect(address3.editable?).to eq(false)
+      expect(address4.editable?).to eq(true)
+    end
+
+  end
 end


### PR DESCRIPTION
This Pr
-Adds an address.editable? that checks if that address is used in any packaged or shipped orders.
-uses this method to make so a user cannot edit or delete those addresses in their profile.
-Adds spec for this and reseeds DB to have a shipped and packaged order on user_1 to test this.