### PR TITLE
Refactor cart show page to use dropdown instead of buttons

### DIFF
--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -31,7 +31,8 @@ class Profile::OrdersController < ApplicationController
   end
 
   def create
-    order = Order.create(user: current_user, status: :pending, address_id: params[:address_id])
+    # require "pry"; binding.pry
+    order = Order.create(user: current_user, status: :pending, address_id: params[:address_select])
     cart.items.each do |item, quantity|
       order.order_items.create(item: item, quantity: quantity, price: item.price)
     end

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -4,10 +4,11 @@
 <% else %>
   <h3>Total: <%= number_to_currency(cart.total) %></h3>
   <% if current_user %>
-    <%  current_user.addresses.each do |address| %>
-      <%= button_to "Check Out #{address.nick_name}", profile_orders_path(address_id: address.id), method: :post %>
-    <% end %>
-
+  <%= form_tag({controller: "profile/orders", action: "create"}, method: :post) do %>
+  <%= label_tag :address_select %>
+  <%= select_tag :address_select, options_for_select(current_user.addresses.map{|a|[a.nick_name, a.id]}) %>
+  <%= submit_tag "Check Out" unless current_user.addresses.empty? %>
+<% end %>
     <% if current_user.addresses.empty? %>
     <%= link_to "You must have an address to check out", new_user_address_path(current_user) %>
     <% end %>

--- a/spec/features/cart/checkout_spec.rb
+++ b/spec/features/cart/checkout_spec.rb
@@ -77,41 +77,25 @@ RSpec.describe "Checking out" do
   end
 
   describe "when checking out" do
-    it "allows me to choose an address to ship to" do
+
+    it "lets me choose an address from a dropdown" do
       user = create(:user)
       a1 = create(:address, user: user)
+      a2 = create(:address, user: user, nick_name: 'school')
+      a3 = create(:address, user: user, nick_name: 'work')
       login_as(user)
       visit cart_path
-
-      click_button "Check Out #{user.addresses[0].nick_name}"
+      select "#{a3.nick_name}", from:  "address_select"
+      click_button "Check Out"
       new_order = Order.last
       expect(current_path).to eq(profile_orders_path)
       within("#order-#{new_order.id}") do
         expect(page).to have_link("Order ID #{new_order.id}")
         expect(page).to have_content("Status: pending")
-        expect(page).to have_content("Address: #{user.addresses[0].nick_name}")
+        expect(page).to have_content("Address: #{a3.nick_name}")
       end
+
     end
-
-      it "shows multiple checkout options If I have multiple addresses" do
-        user = create(:user)
-        a1 = create(:address, user: user)
-        a2 = create(:address, user: user, nick_name: 'school')
-        a3 = create(:address, user: user, nick_name: 'work')
-        login_as(user)
-        visit cart_path
-
-        expect(page).to have_button("Check Out #{user.addresses[0].nick_name}")
-        expect(page).to have_button("Check Out #{user.addresses[1].nick_name}")
-        expect(page).to have_button("Check Out #{user.addresses[2].nick_name}")
-        click_button "Check Out #{user.addresses[2].nick_name}"
-        new_order = Order.last
-        within("#order-#{new_order.id}") do
-          expect(page).to have_link("Order ID #{new_order.id}")
-          expect(page).to have_content("Status: pending")
-          expect(page).to have_content("Address: #{user.addresses[2].nick_name}")
-        end
-      end
     it "does not let me checkout with no addresses" do
         user = create(:user)
         login_as(user)


### PR DESCRIPTION
This PR
-Removes button tests and functionality from cart checkout page
-Now has spec and checks out via a dropdown menu